### PR TITLE
Adding Types to represent Epsilon AST

### DIFF
--- a/cse230-debugger.cabal
+++ b/cse230-debugger.cabal
@@ -5,21 +5,6 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
-Library
-  ghc-options:        -W
-  exposed-modules:    Epsilon.Types
-
-  Default-Extensions: OverloadedStrings
-
-  -- other-extensions:
-  build-depends:       base,
-                       parsec,
-                       containers,
-                       mtl
-
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-
 executable debugger
   hs-source-dirs:      src
   main-is:             Main.hs
@@ -36,3 +21,32 @@ executable debugger
                      , vty
                      , WEditor
                      , WEditorBrick
+
+Library
+  ghc-options:        -W
+  exposed-modules:    Epsilon.Types,
+                      Epsilon.Parser
+
+  Default-Extensions: OverloadedStrings
+
+  -- other-extensions:
+  build-depends:       base,
+                       parsec,
+                       containers,
+                       mtl
+
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+Test-Suite test-epsilon-delta
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  hs-source-dirs:      test
+
+  build-depends:       base,
+                       parsec,
+                       tasty,
+                       tasty-hunit,
+                       tasty-quickcheck,
+                       cse230-debugger
+  other-modules:       Epsilon.ParserTest

--- a/cse230-debugger.cabal
+++ b/cse230-debugger.cabal
@@ -5,6 +5,21 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+Library
+  ghc-options:        -W
+  exposed-modules:    Epsilon.Types
+
+  Default-Extensions: OverloadedStrings
+
+  -- other-extensions:
+  build-depends:       base,
+                       parsec,
+                       containers,
+                       mtl
+
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
 executable debugger
   hs-source-dirs:      src
   main-is:             Main.hs

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  stack:

--- a/src/Epsilon/Parser.hs
+++ b/src/Epsilon/Parser.hs
@@ -1,0 +1,107 @@
+module Epsilon.Parser where
+
+import qualified Epsilon.Types as T
+import Data.Map
+import Text.Parsec
+import Text.Parsec.String
+ 
+
+-- Helper to parse some particular string and return an AST Node
+constP :: String -> a -> Parser a
+constP s a = do
+  string s
+  return a
+
+-------------------------------------------------
+--        PARSING PRIMITIVE VALUES
+-------------------------------------------------
+
+valueP :: Parser T.Value
+valueP =  intValP
+      <|> boolValP
+      <|> charValP
+      <|> stringValP
+      <|> listValP
+      <|> mapValP
+--    <|> closureP TODO: After statementP is available
+
+-- TODO: negative integer literals
+intValP :: Parser T.Value
+intValP = do
+  intStr <- many1 digit
+  return $ T.IntVal $ read intStr
+
+boolValP :: Parser T.Value
+boolValP = constP "true" (T.BoolVal True) 
+        <|> constP "false" (T.BoolVal False)
+
+charValP :: Parser T.Value
+charValP =  T.CharVal 
+        <$> between (char '\'') (char '\'') anyChar
+
+stringValP :: Parser T.Value
+stringValP =  T.StringVal 
+          <$> stringLiteral
+
+stringLiteral :: Parser String
+stringLiteral = between (char '"') (char '"') (many quotedChar)
+
+quotedChar :: Parser Char
+quotedChar =  unescapedChar 
+          <|> escapedChar
+
+unescapedChar :: Parser Char
+unescapedChar = noneOf ['"', '\\']
+
+escapedChar :: Parser Char
+escapedChar = do
+  char '\\'
+  c <- oneOf ['\\', '"', 'r', 'n']
+  return $ case c of
+    '\\' -> '\\'
+    '"' -> '"'
+    'r' -> '\r'
+    'n' -> '\n'
+    c -> c
+
+-- Parser for the separator between consecutive list/ map items/entries
+itemSep :: Parser ()
+itemSep = do
+  many space 
+  char ','
+  many space
+  return ()
+
+listValP :: Parser T.Value
+listValP = T.ListVal 
+        <$> (between (char '[') (char ']') listItems)
+
+-- TODO: list items can be any expression
+listItems :: Parser [T.Value]
+listItems = valueP `sepBy`  
+            itemSep
+
+mapValP :: Parser T.Value
+mapValP = do
+  string "map"
+  entries <- between (char '{') (char '}') mapEntries 
+  return $ T.MapVal $ fromList entries
+
+mapEntries :: Parser [(String, T.Value)]
+mapEntries = mapEntry `sepBy`
+             itemSep
+
+-- Parser for the separator between the map entry's key and value
+kvSep :: Parser ()
+kvSep = do
+  many space 
+  char ':'
+  many space
+  return ()
+
+mapEntry :: Parser (String, T.Value)
+mapEntry = do
+  key <- stringLiteral
+  kvSep
+  value <- valueP
+  return (key, value)

--- a/src/Epsilon/Types.hs
+++ b/src/Epsilon/Types.hs
@@ -1,0 +1,73 @@
+module Epsilon.Types where
+
+import Data.Map
+
+-------------------------------------------------
+--             PRIMITIVE VALUES
+-------------------------------------------------
+
+data Value
+  = IntVal Int
+  | BoolVal Bool
+  | CharVal Char
+  | StringVal String
+  | ListVal [Value]
+  | MapVal (Map String Value)
+  | Closure [String] Statement
+  deriving (Eq, Show)
+
+-------------------------------------------------
+--             VARIABLES
+-------------------------------------------------
+
+type Variable = String
+
+-------------------------------------------------
+--             UNARY OPERATORS
+-------------------------------------------------
+
+data UnOp
+  = Not
+  deriving (Eq, Show)
+
+-------------------------------------------------
+--             BINARY OPERATORS
+-------------------------------------------------
+
+data BinOp
+  = Add
+  | Sub
+  | Mul
+  | Div
+  | Lte
+  | Gte
+  | Lt
+  | Gt
+  | Idx
+  | Or
+  | And
+  deriving (Eq, Show)
+
+-------------------------------------------------
+--             EXPRESSIONS
+-------------------------------------------------
+
+data Expression
+  = Var Variable
+  | Val Value
+  | BinOpExpr BinOp Expression Expression
+  | UnOpExpr UnOp Expression
+  | Call Expression [Expression]
+  deriving (Eq, Show)
+
+-------------------------------------------------
+--             STATEMENTS
+-------------------------------------------------
+
+data Statement
+  = Expr Expression
+  | Nop
+  | Sequence [Statement]
+  | IfElse Expression Statement Statement
+  | While Expression Statement
+  deriving (Eq, Show)

--- a/src/Epsilon/Types.hs
+++ b/src/Epsilon/Types.hs
@@ -13,7 +13,7 @@ data Value
   | StringVal String
   | ListVal [Value]
   | MapVal (Map String Value)
-  | Closure [String] Statement
+  | Closure [String] Statement -- TODO: Closure may need a field to capture their lexical environment
   deriving (Eq, Show)
 
 -------------------------------------------------

--- a/test/Epsilon/ParserTest.hs
+++ b/test/Epsilon/ParserTest.hs
@@ -1,0 +1,47 @@
+module Epsilon.ParserTest where
+
+import Epsilon.Types
+import Epsilon.Parser
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+import Text.Parsec
+import Text.Parsec.String
+
+
+assertParser :: (Eq a, Show a) => String -> Parser a -> a -> Assertion
+assertParser input parser expected = assertEqual "" (Right expected) result
+  where
+    result = runParser parser () "TEST-CASE" input
+
+assertBParser :: (Eq a, Show a) => String -> Parser a -> a -> Bool
+assertBParser input parser expected = (Right expected) == result
+  where
+    result = runParser parser () "TEST-CASE" input
+
+testIntValP :: TestTree
+testIntValP = testGroup "intValP" 
+  [ testCase "single digit integer" $ assertParser "1" intValP (IntVal 1)
+  , testCase "multiple digit integer" $ assertParser "1236" intValP (IntVal 1236)
+  , testProperty "parse positive integer literals" $ \n -> (n :: Int) >= 0 ==> assertBParser (show n) intValP (IntVal n)
+  ]
+
+testBoolValP :: TestTree
+testBoolValP = testGroup "boolValP"
+  [ testCase "true" $ assertParser "true" boolValP (BoolVal True)
+  , testCase "false" $ assertParser "false" boolValP (BoolVal False)
+  ]
+
+testCharValP :: TestTree
+testCharValP = testGroup "charValP"
+  [ testCase "simple character literal" $ assertParser "'c'" charValP (CharVal 'c')
+  , testCase "escaped character" $ assertParser "'\n'" charValP (CharVal '\n')
+  , testProperty "parse character literals" $ \c -> assertBParser (['\'', c, '\'']) charValP (CharVal c)
+  ]
+
+testStringValP :: TestTree
+testStringValP = testGroup "stringValP"
+  [ testCase "simple string literal" $ assertParser "\"hello world\"" stringValP (StringVal "hello world")
+  , testCase "simple string literal with escape sequences" $ assertParser "\"hello \\\"\n world\"" stringValP (StringVal "hello \"\n world")
+  ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,14 @@
+import Test.Tasty
+
+import Epsilon.Parser
+import Epsilon.ParserTest
+
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests"
+  [ testIntValP
+  , testBoolValP
+  , testCharValP
+  , testStringValP
+  ]


### PR DESCRIPTION
- Added cabal library for Epsilon so that it is compiled and importable from other modules
- Added hie.yaml since my hlint seems to require it for some reason to work properly
- Added Type module under Epsilon. These are very initial and subject to change obviously.

TODO:
"Closures" need to capture state/environment in some way
It's not immediately obvious how single line lambdas will look and if it makes sense to  allow only statement for the body.